### PR TITLE
Adding more tests against populating the repo from actual rss

### DIFF
--- a/src/main/java/com/podcase/model/Episode.java
+++ b/src/main/java/com/podcase/model/Episode.java
@@ -43,7 +43,6 @@ public class Episode {
 	@Column(name = "publication_date")
 	private Date publicationDate;
 	
-	@NotBlank
 	@Field(analyzer = @Analyzer(definition = "textanalyzer"))
 	@Size(max = 4000)
 	private String description;

--- a/src/main/java/com/podcase/model/Podcast.java
+++ b/src/main/java/com/podcase/model/Podcast.java
@@ -27,7 +27,6 @@ public class Podcast {
 	@Size(max = 4000)
 	private String name;
 	
-	@NotBlank
 	@Field(analyzer = @Analyzer(definition = "textanalyzer"))
 	@Size(max = 4000)
 	private String author;
@@ -50,7 +49,6 @@ public class Podcast {
 	@Column(name = "last_build_date")
 	private Date lastBuildDate;
 
-	@NotBlank
 	@Field(analyzer = @Analyzer(definition = "textanalyzer"))
 	@Size(max = 4000)
 	private String description;

--- a/src/test/java/com/podcase/repository/EpisodeRepositoryTest.java
+++ b/src/test/java/com/podcase/repository/EpisodeRepositoryTest.java
@@ -16,8 +16,10 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.podcase.model.Episode;
 
@@ -42,10 +44,12 @@ public class EpisodeRepositoryTest extends AbstractRepositoryTest {
 		episode.setPublicationDate(new Date());
 	}
 
+	@Rollback
 	@After
 	public void tearDown() throws Exception {
 	}
 
+	@Transactional
 	@Test
 	public void testGetSingleEpisodeById() {
 		persist(episode);

--- a/src/test/java/com/podcase/repository/FullRepositoryTest.java
+++ b/src/test/java/com/podcase/repository/FullRepositoryTest.java
@@ -16,8 +16,10 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.podcase.model.Episode;
 import com.podcase.model.Podcast;
@@ -72,10 +74,12 @@ public class FullRepositoryTest extends AbstractRepositoryTest {
 		podcast.setAuthor("author");
 	}
 
+	@Rollback
 	@After
 	public void tearDown() throws Exception {
 	}
 
+	@Transactional
 	@Test
 	public void testSubscribingAUserToASinglePodcast() {
 		podcast.addEpisode(episode);
@@ -90,6 +94,7 @@ public class FullRepositoryTest extends AbstractRepositoryTest {
 		assertEquals("episode title", actualEpisode.get().getTitle());
 	}
 	
+	@Transactional
 	@Test
 	public void testSubscribingAUserToMultiplePodcasts() {
 		Podcast pod2 = new Podcast();
@@ -114,6 +119,7 @@ public class FullRepositoryTest extends AbstractRepositoryTest {
 		assertEquals("podcast name 2", podcastTwo.get().getName());
 	}
 	
+	@Transactional
 	@Test
 	public void testSettingTheWatchStateForAnEpisodeThatAUserIsSubscribedTo() {
 		podcast.addEpisode(episode);
@@ -133,6 +139,7 @@ public class FullRepositoryTest extends AbstractRepositoryTest {
 		assertEquals(new Long(1234), actualWatchState.get().getWatchedLength());
 	}
 	
+	@Transactional
 	@Test
 	public void testUpdateWatchStateForAnEpisodeThatAUserIsSubscribedTo() {
 		podcast.addEpisode(episode);
@@ -158,6 +165,7 @@ public class FullRepositoryTest extends AbstractRepositoryTest {
 		assertEquals(new Long(12345), actualUpdatedWatchState.get().getWatchedLength());
 	}
 	
+	@Transactional
 	@Test
 	public void testNoDuplicatesAfterUpdateOfWatchState() {
 		podcast.addEpisode(episode);

--- a/src/test/java/com/podcase/repository/PodcastRepositoryTest.java
+++ b/src/test/java/com/podcase/repository/PodcastRepositoryTest.java
@@ -13,8 +13,10 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.podcase.model.Episode;
 import com.podcase.model.Podcast;
@@ -42,10 +44,12 @@ public class PodcastRepositoryTest extends AbstractRepositoryTest {
 		podcast.setAuthor("author");
 	}
 
+	@Rollback
 	@After
 	public void tearDown() throws Exception {
 	}
 
+	@Transactional
 	@Test
 	public void testGetSinglePodcastById() {
 		persist(podcast);	
@@ -56,6 +60,7 @@ public class PodcastRepositoryTest extends AbstractRepositoryTest {
 		assertEquals(id, actualPodcast.get().getId());
 	}
 	
+	@Transactional
 	@Test
 	public void testGetSinglePodcastByName() {
 		String expectedName = "Podcast Name";
@@ -65,6 +70,7 @@ public class PodcastRepositoryTest extends AbstractRepositoryTest {
 		assertEquals(expectedName, actualPodcast.get().getName());
 	}
 	
+	@Transactional
 	@Test
 	public void testGetPodcastLink() {
 		String expectedLink = "http://www.lasertimepodcast.com";
@@ -74,6 +80,7 @@ public class PodcastRepositoryTest extends AbstractRepositoryTest {
 		assertEquals(expectedLink, actualPodcast.get().getLink());
 	}
 
+	@Transactional
 	@Test
 	public void testGetPodcastRssFeed() {
 		String expectedRssFeed = "http://www.lasertimepodcast.com/category/lasertimepodcast/feed/";
@@ -83,6 +90,7 @@ public class PodcastRepositoryTest extends AbstractRepositoryTest {
         assertEquals(expectedRssFeed, actualPodcast.get().getRssFeed());
 	}
 	
+	@Transactional
 	@Test
 	public void testGetLastBuildDate() {
 		Date lastBuildDate = new Date();
@@ -92,6 +100,7 @@ public class PodcastRepositoryTest extends AbstractRepositoryTest {
 		assertEquals(lastBuildDate, actualPodcast.get().getLastBuildDate());
 	}
 	
+	@Transactional
 	@Test
 	public void testGetDescription() {
 		String description = "Expected podcast description";
@@ -101,6 +110,7 @@ public class PodcastRepositoryTest extends AbstractRepositoryTest {
 		assertEquals(description, actualPodcast.get().getDescription());
 	}
 	
+	@Transactional
 	@Test
 	public void testAddEpisode() {
 		Episode episode = new Episode();
@@ -116,6 +126,7 @@ public class PodcastRepositoryTest extends AbstractRepositoryTest {
 		assertEquals(1, actualPodcast.get().getEpisodes().size());
 	}
 	
+	@Transactional
 	@Test
 	public void testRemoveEpisode() {
 		Episode episode = new Episode();
@@ -134,6 +145,7 @@ public class PodcastRepositoryTest extends AbstractRepositoryTest {
 		assertEquals(0, actualPodcast.get().getEpisodes().size());
 	}
 	
+	@Transactional
 	@Test
 	public void testEpisodeIsLinkedToPodcast() {
 		Episode episode = new Episode();

--- a/src/test/java/com/podcase/repository/RepositoryGenerationTest.java
+++ b/src/test/java/com/podcase/repository/RepositoryGenerationTest.java
@@ -1,0 +1,144 @@
+package com.podcase.repository;
+
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.Assert.*;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.podcase.factory.PodcastFactory;
+import com.podcase.model.Episode;
+import com.podcase.model.Podcast;
+import com.podcase.model.User;
+import com.podcase.model.WatchState;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+@TestPropertySource(
+		  locations = "classpath:application-integrationtest.properties")
+public class RepositoryGenerationTest extends AbstractRepositoryTest {
+	
+	@Autowired
+	WatchStateRepository watchStateRepository;
+	
+	@Autowired
+	UserRepository userRepository;
+	
+	@Autowired
+	EpisodeRepository episodeRepository;
+	
+	@Autowired
+	PodcastRepository podcastRepository;
+	
+	WatchState watchState;
+	
+	User user;
+	
+	Episode episode;
+
+	Podcast podcast;
+	
+	@Before
+	public void setUp() throws Exception {
+		user = new User();
+		user.setName("Name");
+		user.setPassword("password");
+		
+		episode = new Episode();
+		episode.setTitle("episode title");
+		episode.setLink("link");
+		episode.setFileUrl("fileUrl");
+		episode.setDescription("description");
+		episode.setPublicationDate(new Date());
+		
+		podcast = new Podcast();
+		podcast.setName("podcast name");
+		podcast.setLink("link");
+		podcast.setRssFeed("blank");
+		podcast.setLastBuildDate(new Date());
+		podcast.setDescription("description");
+		podcast.setAuthor("author");
+	}
+	
+	@Rollback
+	@After
+	public void tearDown() {
+		
+	}
+	
+	@Transactional
+	@Test
+	public void testRepositoryEpisodeCountFromNonItunes() throws MalformedURLException {
+		File file = new File(getClass().getClassLoader().getResource("lasertime.xml").getFile());
+		podcast = PodcastFactory.generate(file.toURI().toURL().toString());
+		persist(podcast);
+		
+		List<Episode> episodes = episodeRepository.findAll();
+		assertEquals(411, episodes.size());
+	}
+	
+	@Transactional
+	@Test
+	public void testRepositoryEpisodeCountFromItunes() throws MalformedURLException {
+		File file = new File(getClass().getClassLoader().getResource("sincast.xml").getFile());
+		podcast = PodcastFactory.generate(file.toURI().toURL().toString());
+		persist(podcast);
+		
+		List<Episode> episodes = episodeRepository.findAll();
+		assertEquals(282, episodes.size());
+	}
+	
+	@Transactional
+	@Test
+	public void testRepositoryEpisodePropertiesFromNonItunes() throws MalformedURLException {
+		File file = new File(getClass().getClassLoader().getResource("lasertime.xml").getFile());
+		podcast = PodcastFactory.generate(file.toURI().toURL().toString());
+		persist(podcast);
+		
+		List<Episode> episodes = episodeRepository.findAll();
+		for (Episode episode : episodes) {
+			assertEquals("http://www.lasertimepodcast.com", episode.getPodcast().getLink());
+			assertNotNull(episode.getTitle());
+			assertNotNull(episode.getLink());
+			assertNotNull(episode.getFileUrl());
+			assertNotNull(episode.getFileType());
+			assertNotNull(episode.getFileLength());
+			assertNotNull(episode.getPublicationDate());
+		}
+	}
+	
+	@Transactional
+	@Test
+	public void testRepositoryEpisodePropertiesFromItunes() throws MalformedURLException {
+		File file = new File(getClass().getClassLoader().getResource("sincast.xml").getFile());
+		podcast = PodcastFactory.generate(file.toURI().toURL().toString());
+		persist(podcast);
+		
+		List<Episode> episodes = episodeRepository.findAll();
+		for (Episode episode : episodes) {
+			assertEquals("SinCast - Presented by CinemaSins", episode.getPodcast().getName());
+			assertEquals("http://cinemasins.com/blog/", episode.getPodcast().getLink());
+			assertNotNull(episode.getTitle());
+			assertNotNull(episode.getLink());
+			assertNotNull(episode.getFileUrl());
+			assertNotNull(episode.getPublicationDate());
+			assertNotNull(episode.getFileType());
+			assertNotNull(episode.getFileLength());
+		}
+	}
+}

--- a/src/test/java/com/podcase/repository/UserRepositoryTest.java
+++ b/src/test/java/com/podcase/repository/UserRepositoryTest.java
@@ -19,8 +19,10 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.podcase.model.Podcast;
 import com.podcase.model.User;
@@ -43,10 +45,12 @@ public class UserRepositoryTest extends AbstractRepositoryTest {
 		user.setPassword("password");
 	}
 
+	@Rollback
 	@After
 	public void tearDown() throws Exception {
 	}
 
+	@Transactional
 	@Test
 	public void testGetSingleUserByName() {
 		String name = "rob";
@@ -56,6 +60,7 @@ public class UserRepositoryTest extends AbstractRepositoryTest {
 		assertEquals(name, actualUser.get().getName());
 	}
 	
+	@Transactional
 	@Test(expected = PersistenceException.class)
 	public void testNoDuplicateNamesPossible() {
 		String name = "rob";

--- a/src/test/java/com/podcase/repository/WatchStateRepositoryTest.java
+++ b/src/test/java/com/podcase/repository/WatchStateRepositoryTest.java
@@ -16,8 +16,10 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.podcase.model.Episode;
 import com.podcase.model.User;
@@ -60,10 +62,12 @@ public class WatchStateRepositoryTest extends AbstractRepositoryTest {
 		episode.setPublicationDate(new Date());
 	}
 
+	@Rollback
 	@After
 	public void tearDown() throws Exception {
 	}
 
+	@Transactional
 	@Test
 	public void testGetWatchStateByUserIdAndEpisodeId() {
 		persist(user);


### PR DESCRIPTION
These tests should hopefully test populating the repository with actual data from real podcast rss files.

I also turned all repo tests into Transactional ones so they should be properly rolled back after each test.