### PR TITLE
Optimize rendering calls

### DIFF
--- a/frontend/podcase/src/App.tsx
+++ b/frontend/podcase/src/App.tsx
@@ -13,14 +13,17 @@ import AddBoxIcon from '@mui/icons-material/AddBox';
 import InputBase from '@mui/material/InputBase';
 import SearchIcon from '@mui/icons-material/Search';
 import { BrowserRouter, Routes, Route, useNavigate } from "react-router-dom";
-import { GridRoutes, SubscribedEpisode, Episode } from './Types';
+import { GridRoutes, SubscribedEpisode, Episode, Podcast } from './Types';
 import Playbar from './components/Playbar/Playbar';
 import {getMostRecentPlayedEpisode} from './services/PodcaseAPIService';
+import Header from './components/Header/Header';
 
 function App() {
 
   const [currentEpisode, setCurrentEpisode] = useState<SubscribedEpisode>(); //TODO use SubscribedEpisode when backend is updated
-
+  const [podcasts, setPodcasts] = useState<Podcast[]>([]);
+  const [headerText, setHeaderText] = useState<string>("");
+  
   useEffect(() => {
     if (!currentEpisode) {
       getMostRecentPlayedEpisode(setCurrentEpisode, ()=>{});
@@ -76,26 +79,7 @@ function App() {
     <BrowserRouter>
       <Box sx={{ display: 'flex' }}>
         <CssBaseline />
-        <AppBar
-          position="fixed"
-          sx={{ width: `calc(100% - ${drawerWidth}px)`, ml: `${drawerWidth}px` }}
-        >
-          <Toolbar>
-            <Typography variant="h6" noWrap component="div" sx={{ flexGrow: 1, display: { xs: 'none', sm: 'block' } }}>
-              Podcase
-          </Typography>
-            <Search>
-              <SearchIconWrapper>
-                <SearchIcon />
-              </SearchIconWrapper>
-              <StyledInputBase
-                placeholder="Search…"
-                inputProps={{ 'aria-label': 'search' }}
-              />
-            </Search>
-          </Toolbar>
-
-        </AppBar>
+        <Header headerText={headerText}></Header>
         <SideBar></SideBar>
         <Box component="main" sx={{ width: "100%" }}>
           <Box
@@ -103,9 +87,9 @@ function App() {
           >
             <Toolbar />
             <Routes>
-              <Route path="/" element={<PodcastGrid state={GridRoutes.PODCAST_SUBSCRIPTION}></PodcastGrid>} />
-              <Route path="all" element={<PodcastGrid state={GridRoutes.PODCAST_ALL}></PodcastGrid>} />
-              <Route path="/podcast/:id" element={<PodcastList setCurrentEpisode={setCurrentEpisode}></PodcastList>} />
+              <Route path="/" element={<PodcastGrid state={GridRoutes.PODCAST_SUBSCRIPTION} podcasts={podcasts} setPodcasts={setPodcasts}></PodcastGrid>} />
+              <Route path="all" element={<PodcastGrid state={GridRoutes.PODCAST_ALL} podcasts={podcasts} setPodcasts={setPodcasts}></PodcastGrid>} />
+              <Route path="/podcast/:id" element={<PodcastList setCurrentEpisode={setCurrentEpisode} setHeaderText={setHeaderText}></PodcastList>} />
             </Routes>
           </Box>
           <Playbar currentEpisode={currentEpisode}></Playbar>

--- a/frontend/podcase/src/components/Header/Header.tsx
+++ b/frontend/podcase/src/components/Header/Header.tsx
@@ -1,8 +1,78 @@
-const Header = () => {
-    return (
-        <div>
+import CssBaseline from '@mui/material/CssBaseline';
+import AppBar from '@mui/material/AppBar';
+import Typography from '@mui/material/Typography';
+import InputBase from '@mui/material/InputBase';
+import SearchIcon from '@mui/icons-material/Search';
+import { Toolbar } from '@mui/material';
+import { styled, alpha } from '@mui/material/styles';
 
-        </div>
+const Header = (props: any) => {
+
+    const drawerWidth = 240;
+
+    const Search = styled('div')(({ theme }: any) => ({
+        position: 'relative',
+        borderRadius: theme.shape.borderRadius,
+        backgroundColor: alpha(theme.palette.common.white, 0.15),
+        '&:hover': {
+            backgroundColor: alpha(theme.palette.common.white, 0.25),
+        },
+        marginLeft: 0,
+        width: '100%',
+        [theme.breakpoints.up('sm')]: {
+            marginLeft: theme.spacing(1),
+            width: 'auto',
+        },
+    }));
+
+    const SearchIconWrapper = styled('div')(({ theme }) => ({
+        padding: theme.spacing(0, 2),
+        height: '100%',
+        position: 'absolute',
+        pointerEvents: 'none',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+    }));
+
+    const StyledInputBase = styled(InputBase)(({ theme }) => ({
+        color: 'inherit',
+        '& .MuiInputBase-input': {
+            padding: theme.spacing(1, 1, 1, 0),
+            // vertical padding + font size from searchIcon
+            paddingLeft: `calc(1em + ${theme.spacing(4)})`,
+            transition: theme.transitions.create('width'),
+            width: '100%',
+            [theme.breakpoints.up('sm')]: {
+                width: '12ch',
+                '&:focus': {
+                    width: '20ch',
+                },
+            },
+        },
+    }));
+
+    return (
+        <AppBar
+            position="fixed"
+            sx={{ width: `calc(100% - ${drawerWidth}px)`, ml: `${drawerWidth}px` }}
+        >
+            <Toolbar>
+                <Typography variant="h6" noWrap component="div" sx={{ flexGrow: 1, display: { xs: 'none', sm: 'block' } }}>
+                    {props.headerText}
+                </Typography>
+                <Search>
+                    <SearchIconWrapper>
+                        <SearchIcon />
+                    </SearchIconWrapper>
+                    <StyledInputBase
+                        placeholder="Search…"
+                        inputProps={{ 'aria-label': 'search' }}
+                    />
+                </Search>
+            </Toolbar>
+
+        </AppBar>
     )
 }
 

--- a/frontend/podcase/src/components/PodcastGrid/PodcastGrid.tsx
+++ b/frontend/podcase/src/components/PodcastGrid/PodcastGrid.tsx
@@ -1,26 +1,27 @@
 import Grid from '@mui/material/Grid';
 import React, {useEffect, useState} from 'react';
 import { getUserSubscriptions, getAllPodcasts } from '../../services/PodcaseAPIService';
-import { GridRoutes, SubscribedPodcast } from '../../Types';
+import { GridRoutes, Podcast, SubscribedPodcast } from '../../Types';
 import PodcastGridItem from '../PodcastGridItem/PodcastGridItem';
+import {useLocation} from "react-router-dom";
 
 const PodcastGrid = (props: any) => {
 
-    const [podcasts, setPodcasts] = useState<SubscribedPodcast[]>([]);
+    const location = useLocation();
 
     useEffect(() => {
         if (props && props.state === GridRoutes.PODCAST_ALL) {
-            getAllPodcasts(setPodcasts, () => {});
+            getAllPodcasts(props.setPodcasts, () => {});
         } else if (props && props.state === GridRoutes.PODCAST_SUBSCRIPTION) {
-            getUserSubscriptions(1, setPodcasts, () => {});
+            getUserSubscriptions(1, props.setPodcasts, () => {});
         }
         
-    }, [podcasts]);
+    }, [location]);
 
     return (
             <Grid container spacing={2} key="podcastGrid">
             {
-                podcasts.map(podcast => {
+                props.podcasts.map((podcast: Podcast) => {
                     return <PodcastGridItem key={podcast.id} id={podcast.id} description={podcast.description} imageUrl={podcast.imageUrl} name={podcast.name}></PodcastGridItem>
                 })
             }

--- a/frontend/podcase/src/components/PodcastList/PodcastList.tsx
+++ b/frontend/podcase/src/components/PodcastList/PodcastList.tsx
@@ -2,7 +2,7 @@ import { Box, List, ListItem, ListItemText, CircularProgress } from '@mui/materi
 import { Podcast, SubscribedEpisode } from '../../Types';
 import EpisodeListItem from '../Episode/EpisodeListItem';
 import React, { useEffect, useState } from 'react';
-import { getPodcastEpisodes } from '../../services/PodcaseAPIService';
+import { getPodcast, getPodcastEpisodes } from '../../services/PodcaseAPIService';
 import { useParams } from "react-router-dom";
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
@@ -14,9 +14,15 @@ const PodcastList = (props: any) => {
     const [episodes, setEpisodes] = useState<SubscribedEpisode[]>();
     const [description, setDescription] = useState<string>("");
     const [open, setOpen] = useState<boolean>(false); 
+    const [podcast, setPodcast] = useState<Podcast>();
 
     useEffect(() => {
         if (id && id !== "") {
+            const setPodcastProps = (podcast: Podcast) => {
+                setPodcast(podcast);
+                props.setHeaderText(podcast.name);
+            }
+            getPodcast(parseInt(id), setPodcastProps, () => {});
             getPodcastEpisodes(parseInt(id), setEpisodes, () => { });
         }
     }, []);

--- a/frontend/podcase/src/components/SideBar/SideBar.tsx
+++ b/frontend/podcase/src/components/SideBar/SideBar.tsx
@@ -1,50 +1,61 @@
 import { Divider, Drawer, List, ListItem, ListItemText, Toolbar } from '@mui/material';
-import {BrowserRouter,  Routes,  Route, useNavigate, Link} from "react-router-dom";
+import { BrowserRouter, Routes, Route, useNavigate, Link } from "react-router-dom";
 import PodcastsIcon from '@mui/icons-material/Podcasts';
 import BookmarkBorderIcon from '@mui/icons-material/BookmarkBorder';
 import AddBoxIcon from '@mui/icons-material/AddBox';
 import { GridRoutes } from '../../Types';
+import Typography from '@mui/material/Typography';
+import AppBar from '@mui/material/AppBar';
 
 const SideBar = () => {
-    const drawerWidth = 240;
-    const navigate = useNavigate();
+  const drawerWidth = 240;
+  const navigate = useNavigate();
 
-    return (
-        <Drawer
-          sx={{
-            width: drawerWidth,
-            flexShrink: 0,
-            '& .MuiDrawer-paper': {
-              width: drawerWidth,
-              boxSizing: 'border-box',
-            },
-          }}
-          variant="permanent"
-          anchor="left"
-        >
-          <Toolbar />
-          <Divider />
-          <List>
-            <ListItem button key='Subscriptions' onClick={() => navigate("/", {state: {podcastState: GridRoutes.PODCAST_SUBSCRIPTION}})}>
-              <PodcastsIcon></PodcastsIcon>
-              <ListItemText primary='Subscriptions' />
-            </ListItem>
-            <ListItem button key='All Podcasts' onClick={() => navigate("/all", {state: {podcastState: GridRoutes.PODCAST_ALL}})}>
-              <PodcastsIcon></PodcastsIcon>
-              <ListItemText primary='All Podcasts' />
-            </ListItem>
-            <ListItem button key='Favourites'>
-              <BookmarkBorderIcon></BookmarkBorderIcon>
-              <ListItemText primary='Favourites' />
-            </ListItem>
-            <ListItem button key='Add Subscription'>
-              <AddBoxIcon></AddBoxIcon>
-              <ListItemText primary='Add Subscription' />
-            </ListItem>
-          </List>
-          <Divider />
-        </Drawer>
-    )
+  return (
+    <Drawer
+      sx={{
+        width: drawerWidth,
+        flexShrink: 0,
+        '& .MuiDrawer-paper': {
+          width: drawerWidth,
+          boxSizing: 'border-box',
+        },
+      }}
+      variant="permanent"
+      anchor="left"
+    >
+      <Toolbar sx={{
+        backgroundColor: "#1976d2",
+        color: "white",
+      }}>
+        <Typography variant="h6">
+          Podcase
+          </Typography>
+      </Toolbar>
+
+
+      <Divider />
+      <List>
+        <ListItem button key='Subscriptions' onClick={() => navigate("/", { state: { podcastState: GridRoutes.PODCAST_SUBSCRIPTION } })}>
+          <PodcastsIcon></PodcastsIcon>
+          <ListItemText primary='Subscriptions' />
+        </ListItem>
+        <ListItem button key='All Podcasts' onClick={() => navigate("/all", { state: { podcastState: GridRoutes.PODCAST_ALL } })}>
+          <PodcastsIcon></PodcastsIcon>
+          <ListItemText primary='All Podcasts' />
+        </ListItem>
+        <ListItem button key='Favourites'>
+          <BookmarkBorderIcon></BookmarkBorderIcon>
+          <ListItemText primary='Favourites' />
+        </ListItem>
+        <ListItem button key='Add Subscription'>
+          <AddBoxIcon></AddBoxIcon>
+          <ListItemText primary='Add Subscription' />
+        </ListItem>
+      </List>
+      <Divider />
+    </Drawer >
+  )
 }
 
 export default SideBar;

--- a/frontend/podcase/src/services/PodcaseAPIService.ts
+++ b/frontend/podcase/src/services/PodcaseAPIService.ts
@@ -1,4 +1,4 @@
-import { Episode, SubscribedPodcast } from "../Types";
+import { Episode, Podcast, SubscribedPodcast } from "../Types";
 
 
 
@@ -15,6 +15,23 @@ export const getUserSubscriptions = async (userId: number, success: Function, er
         }).catch(exception => {
             error(exception);
         });
+}
+
+//TODO only return podcast and not its episodes
+export const getPodcast = async (podcastId: number, success: Function, error: Function) => {
+    const url = `${process.env.REACT_APP_PODCASE_BASE_URL}podcasts/${podcastId}`;
+    await fetch(url).then(
+        (response) => {
+            if (!response.ok) {
+                throw new Error(response.statusText)
+            }
+            return response.json() as unknown as Podcast;
+        }
+    ).then(podcast => {
+        success(podcast);
+    }).catch(exception => {
+        error(exception);
+    })
 }
 
 export const getAllPodcasts = async (success: Function, error: Function) => {


### PR DESCRIPTION
episode list call was running in an infinite loop.
Now we only rely on the location changing in order to force a re-render
Also moved the header text and show podcast title in AppBar