### PR TITLE
Optimize image in episode list

### DIFF
--- a/frontend/podcase/src/Types.ts
+++ b/frontend/podcase/src/Types.ts
@@ -10,7 +10,7 @@ export interface Podcast {
     rssFeed: string;
 }
 
-export type SubscribedPodcast = Pick<Podcast, "id" | "description" | "imageUrl" | "name">
+export type SubscribedPodcast = Pick<Podcast, "id" | "description" | "imageUrl" | "name">;
 
 export interface Episode {
     id: number;

--- a/frontend/podcase/src/components/Episode/EpisodeListItem.tsx
+++ b/frontend/podcase/src/components/Episode/EpisodeListItem.tsx
@@ -20,9 +20,10 @@ interface EpisodeListItemInterface {
     setCurrentEpisode: Function;
     setDialogOpen: Function;
     setDialogDescription: Function;
+    imageUrl: string;
 }
 
-const EpisodeListItem = ({ episode, setCurrentEpisode, setDialogOpen, setDialogDescription }: EpisodeListItemInterface) => {
+const EpisodeListItem = ({ episode, setCurrentEpisode, setDialogOpen, setDialogDescription, imageUrl }: EpisodeListItemInterface) => {
 
     const options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
     const pubDate = new Date(episode.publication_date);
@@ -59,7 +60,7 @@ const EpisodeListItem = ({ episode, setCurrentEpisode, setDialogOpen, setDialogD
                                 marginTop="20%"
                             >
                                 <ListItemAvatar>
-                                    <img src={episode.image_url} height="60" width="60" />
+                                    <img src={imageUrl} height="60" width="60" />
                                 </ListItemAvatar>
                             </Box>
 

--- a/frontend/podcase/src/components/PodcastList/PodcastList.tsx
+++ b/frontend/podcase/src/components/PodcastList/PodcastList.tsx
@@ -29,7 +29,7 @@ const PodcastList = (props: any) => {
     return (
         <Box>
             {
-                episodes && episodes.length > 0 ?
+                podcast && episodes && episodes.length > 0 ?
                     <div>
                         <Dialog open={open} onClose={() => {setOpen(false);}}>
                             {description}
@@ -41,6 +41,7 @@ const PodcastList = (props: any) => {
                                     setCurrentEpisode={props.setCurrentEpisode} 
                                     setDialogDescription={setDescription} 
                                     setDialogOpen={setOpen}
+                                    imageUrl={podcast.imageUrl}
                                     >                                        
                                     </EpisodeListItem>
                                 })

--- a/src/main/java/com/podcase/repository/PodcastRepository.java
+++ b/src/main/java/com/podcase/repository/PodcastRepository.java
@@ -27,7 +27,7 @@ public interface PodcastRepository extends JpaRepository<Podcast, Long> {
 
 	Optional<Podcast> findByDescription(String description);
 	
-	@Query(value="SELECT id, author, description, image_url, last_build_date, link, name, rss_feed from podcast where id= ?1", nativeQuery=true)
+	@Query(value="SELECT id, author, description, image_url as imageUrl, last_build_date as lastBuildDate, link, name, rss_feed as rssFeed from podcast where id= ?1", nativeQuery=true)
 	Optional<PodcastProjection> getPodcastMetadataById(Long id);
 
 	public static final String GET_PODCAST_RSS_FEEDS = "SELECT id, rss_feed FROM podcast";


### PR DESCRIPTION
Previously used the imageUrl from the retrieved episode(s). Which led to
a huge number of http requests for the same image.
Now just using the imageUrl from the Parent podcast entity.