### PR TITLE
The previous fix to update an episode duration was flaky

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,13 @@
 			<artifactId>commons-io</artifactId>
 			<version>2.11.0</version>
 		</dependency>
+		<!-- https://mvnrepository.com/artifact/org/jaudiotagger -->
+		<dependency>
+			<groupId>org</groupId>
+			<artifactId>jaudiotagger</artifactId>
+			<version>2.0.3</version>
+		</dependency>
+
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/podcase/job/EpisodeDownloadJob.java
+++ b/src/main/java/com/podcase/job/EpisodeDownloadJob.java
@@ -13,6 +13,9 @@ import javax.sound.sampled.AudioInputStream;
 import javax.sound.sampled.AudioSystem;
 
 import org.apache.commons.io.FileUtils;
+import org.jaudiotagger.audio.AudioFile;
+import org.jaudiotagger.audio.AudioFileIO;
+import org.jaudiotagger.audio.AudioHeader;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -69,11 +72,14 @@ public class EpisodeDownloadJob implements ScheduledJob {
 				File destination = new File(filePath);
 				FileUtils.copyURLToFile(endpointURL, destination);
 				if (episode.getDuration() == null || episode.getDuration() == 0) {
-					AudioInputStream audioInputStream = AudioSystem.getAudioInputStream(destination);
-					AudioFormat format = audioInputStream.getFormat();
-					long frames = audioInputStream.getFrameLength();
-					double durationInSeconds = (frames+0.0) / format.getFrameRate(); 
-					episode.setDuration(Math.toIntExact(Math.round(durationInSeconds)));
+					AudioFile audioFile = AudioFileIO.read(destination);
+					AudioHeader header = audioFile.getAudioHeader();
+					episode.setDuration(header.getTrackLength());
+//					AudioInputStream audioInputStream = AudioSystem.getAudioInputStream(destination);
+//					AudioFormat format = audioInputStream.getFormat();
+//					long frames = audioInputStream.getFrameLength();
+//					double durationInSeconds = (frames+0.0) / format.getFrameRate(); 
+//					episode.setDuration(Math.toIntExact(Math.round(durationInSeconds)));
 				}
 				episode.setDownloaded(true);
 				repository.save(episode);


### PR DESCRIPTION
Mp3s require a bit more work to calculate the duration.
Passing this complication to jaudiotagger for getting the tracklength.