### PR TITLE
When updating play state now only look for user and episode id

### DIFF
--- a/frontend/podcase/src/App.tsx
+++ b/frontend/podcase/src/App.tsx
@@ -14,7 +14,7 @@ import { getAllUsers, getMostRecentPlayedEpisode, getUserSubscriptions } from '.
 import Header from './components/Header/Header';
 import Users from './components/Users/Users';
 import { AppContext } from './context/context';
-import { changeEpisode, changeSubscriptions, changeUser, stateReducer } from './context/reducer';
+import { changeEpisode, changeSubscriptions, changeUser, stateReducer, setAutoPlay } from './context/reducer';
 import Admin from './components/Admin/Admin';
 import SearchResult from './components/SearchResult/SearchResult';
 
@@ -30,6 +30,7 @@ function App() {
       getAllUsers((users: User[]) => {
         dispatch(changeUser(users[0]));
         getMostRecentPlayedEpisode(users[0].id, (episode: SubscribedEpisode) => {
+          dispatch(setAutoPlay(false));
           dispatch(changeEpisode(episode));
         }, () => {console.log("error getting recent episode") });
         getUserSubscriptions(users[0].id, (podcasts: SubscribedPodcast[]) => {dispatch(changeSubscriptions(podcasts))}, () => {});

--- a/frontend/podcase/src/Types.ts
+++ b/frontend/podcase/src/Types.ts
@@ -131,6 +131,7 @@ export interface NavigationState {
 }
 
 export interface AppState {
+    autoPlay: boolean;
     currentUser: User | null;
     currentEpisode: SubscribedEpisode | null;
     headerText: string;
@@ -143,6 +144,7 @@ export enum ActionType {
     ChangeHeaderText,
     AddSubscription,
     ChangeSubscriptions,
+    SetAutoPlay,
 }
 
 export interface ChangeUser {
@@ -170,11 +172,17 @@ export interface ChangeSubscriptions {
     payload: SubscribedPodcast[];
 }
 
-export type StateActions = ChangeUser | ChangeEpisode | ChangeHeaderText | AddSubscription | ChangeSubscriptions;
+export interface SetAutoPlay {
+    type: ActionType.SetAutoPlay;
+    payload: boolean;
+}
+
+export type StateActions = ChangeUser | ChangeEpisode | ChangeHeaderText | AddSubscription | ChangeSubscriptions | SetAutoPlay;
 
 export const initialAppState: AppState = {
     currentUser: null,
     currentEpisode: null,
     headerText: "",
     userSubscriptions: [],
+    autoPlay: false,
 };

--- a/frontend/podcase/src/components/Episode/EpisodeListItem.tsx
+++ b/frontend/podcase/src/components/Episode/EpisodeListItem.tsx
@@ -13,7 +13,7 @@ import ReactHtmlParser from 'react-html-parser';
 import IconButton from '@mui/material/IconButton';
 import { AppContext } from "../../context/context";
 import { useContext } from 'react';
-import { changeEpisode } from "../../context/reducer";
+import { changeEpisode, setAutoPlay } from "../../context/reducer";
 import { updateLastPlayed } from "../../services/PodcaseAPIService";
 
 
@@ -50,6 +50,7 @@ const EpisodeListItem = ({ episode, setDialogOpen, setDialogDescription, imageUr
                 if (playState.id && playState.id != episode.play_state_id) {
                     episode.play_state_id = playState.id;
                     episode.play_length = playState.playLength ? playState.playLength : 0;
+                    dispatch(setAutoPlay(true));
                     dispatch(changeEpisode(episode));
                 }
             });

--- a/frontend/podcase/src/components/Users/UserItem.tsx
+++ b/frontend/podcase/src/components/Users/UserItem.tsx
@@ -6,7 +6,7 @@ import Box from '@mui/material/Box';
 import { SubscribedEpisode, User } from "../../Types";
 import { AppContext } from "../../context/context";
 import { useContext } from 'react';
-import { changeEpisode, changeUser } from '../../context/reducer';
+import { changeEpisode, changeUser, setAutoPlay } from '../../context/reducer';
 import { getMostRecentPlayedEpisode } from "../../services/PodcaseAPIService";
 
 interface UserItemProperties {
@@ -22,6 +22,7 @@ const UserItem = (userDetails: UserItemProperties) => {
             <Card className="clearClickable" sx={{ maxWidth: 250, maxHeight: 400, border: isSelectedUser ? 1 : 0, borderColor: isSelectedUser ? "primary.main" : undefined }} onClick={() => {
                 dispatch(changeUser(userDetails.user));
                 getMostRecentPlayedEpisode(userDetails.user.id, (episode: SubscribedEpisode) => {
+                    dispatch(setAutoPlay(false));
                     dispatch(changeEpisode(episode));
                   }, () => { console.log("error getting most recently played for:"+userDetails.user.name) });
             }}>

--- a/frontend/podcase/src/context/reducer.ts
+++ b/frontend/podcase/src/context/reducer.ts
@@ -1,4 +1,6 @@
-import { ActionType, AddSubscription, AppState, ChangeEpisode, ChangeHeaderText, ChangeSubscriptions, ChangeUser, StateActions, SubscribedEpisode, SubscribedPodcast, User } from "../Types";
+import { ActionType, AddSubscription, AppState, ChangeEpisode, 
+    ChangeHeaderText, ChangeSubscriptions, ChangeUser, StateActions, 
+    SubscribedEpisode, SubscribedPodcast, SetAutoPlay, User } from "../Types";
 
 export function stateReducer(state: AppState, action: StateActions): AppState {
     switch (action.type) {
@@ -12,6 +14,8 @@ export function stateReducer(state: AppState, action: StateActions): AppState {
             return { ...state, userSubscriptions: [...state.userSubscriptions, action.payload] };
         case ActionType.ChangeSubscriptions:
             return { ...state, userSubscriptions: action.payload};
+        case ActionType.SetAutoPlay:
+            return { ...state, autoPlay: action.payload};
         default:
         return state;
     }
@@ -41,3 +45,9 @@ export const changeSubscriptions = (subscriptions: SubscribedPodcast[]): ChangeS
     type: ActionType.ChangeSubscriptions,
     payload: subscriptions,
 });
+
+export const setAutoPlay = (autoPlay: boolean): SetAutoPlay => ({
+    type: ActionType.SetAutoPlay,
+    payload: autoPlay,
+});
+

--- a/src/main/java/com/podcase/controller/PlayStateController.java
+++ b/src/main/java/com/podcase/controller/PlayStateController.java
@@ -56,8 +56,10 @@ public class PlayStateController {
 	}
 	
 	private PlayState updatePlayState(PlayStateRequest playStateRequest) throws Exception {
-		repository.findById(playStateRequest.getId() == null ? -1 : playStateRequest.getId()).ifPresentOrElse((playState) -> {
+		Optional<PlayState> playStateOpt = repository.findByUserIdAndEpisodeId(playStateRequest.getUserId(), playStateRequest.getEpisodeId());
+		playStateOpt.ifPresentOrElse((playState) -> {
 			playState.setPlayLength(playStateRequest.getPlayLength());
+			playState.setLastPlayed(new Date());
 			this.currentPlayState = repository.save(playState);
 		}, () -> {
 			PlayState playState = new PlayState();


### PR DESCRIPTION
Also fixed issue with timer. The interval id was not staying consistent so the timer would not clear
when the user was changed while an episode was playing. Also allowing for roll over auto play
into the next episode of the podcast correctly